### PR TITLE
Format robux display on roblox page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
+## Roblox Exact Robux (Chrome Extension)
+
+Shows your exact Robux on roblox.com by replacing abbreviated values (e.g., 1M+) in the header with the full number (e.g., 1067530). It fetches your balance from Roblox's official API using your logged-in session cookies.
+
+### Install (Developer Mode)
+
+1. Download or clone this folder to your computer.
+2. Open Chrome and go to `chrome://extensions`.
+3. Toggle on Developer mode (top right).
+4. Click "Load unpacked" and select this folder.
+5. Visit `https://www.roblox.com/` while logged in. The header Robux display should become the exact number.
+
+### Files
+
+- `manifest.json`: Extension configuration (MV3).
+- `background.js`: Service worker that fetches your balance from `https://economy.roblox.com/v1/user/currency`.
+- `content.js`: Injected into roblox.com pages to replace header Robux text and keep it updated as the DOM changes.
+
+### Notes
+
+- The extension only alters header/navigation elements to avoid changing item prices or other numbers.
+- Balance is cached for ~30 seconds to minimize network usage.
+- If you're not logged in or the API is temporarily unavailable, the page will remain unchanged.
+
 # 🎮 Roblox Community RAP Tracker
 
 A Chrome extension that extracts Roblox community members and ranks them by their wealth based on limited items ownership.

--- a/background.js
+++ b/background.js
@@ -1,3 +1,42 @@
+const ROBUX_ENDPOINT = "https://economy.roblox.com/v1/user/currency";
+
+async function fetchExactRobuxBalance() {
+  try {
+    const response = await fetch(ROBUX_ENDPOINT, {
+      method: "GET",
+      credentials: "include",
+      headers: {
+        "accept": "application/json, text/plain, */*",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    const data = await response.json();
+    if (data && typeof data.robux === "number") {
+      return data.robux;
+    }
+    throw new Error("Unexpected response shape");
+  } catch (error) {
+    throw error;
+  }
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message && message.type === "GET_ROBUX_BALANCE") {
+    fetchExactRobuxBalance()
+      .then((robux) => {
+        sendResponse({ ok: true, robux });
+      })
+      .catch((error) => {
+        sendResponse({ ok: false, error: String(error && error.message ? error.message : error) });
+      });
+    return true; // Keep the message channel open for async response
+  }
+});
+
 class RobloxAPIManager {
     constructor() {
         this.baseDelay = 100; // Base delay between requests (ms)

--- a/content.js
+++ b/content.js
@@ -1,0 +1,124 @@
+(function () {
+  const REQUEST_TYPE = "GET_ROBUX_BALANCE";
+  const CACHE_TTL_MS = 30_000; // refresh every 30s to track live changes
+
+  let cachedRobux = null;
+  let cachedAt = 0;
+  let debounceTimer = null;
+
+  function isCacheFresh() {
+    return cachedRobux !== null && Date.now() - cachedAt < CACHE_TTL_MS;
+  }
+
+  function requestRobux() {
+    if (isCacheFresh()) {
+      return Promise.resolve(cachedRobux);
+    }
+    return new Promise((resolve, reject) => {
+      chrome.runtime.sendMessage({ type: REQUEST_TYPE }, (response) => {
+        if (!response || !response.ok) {
+          reject(new Error(response && response.error ? response.error : "Failed to fetch Robux"));
+          return;
+        }
+        cachedRobux = response.robux;
+        cachedAt = Date.now();
+        resolve(cachedRobux);
+      });
+    });
+  }
+
+  function looksLikeAbbreviated(text) {
+    if (!text) return false;
+    const trimmed = text.trim();
+    if (!trimmed) return false;
+    // Common formats: 1,234; 1.2K; 1M+; 1.2M; 999K+
+    return /[,]|\b[KM]\b|[KM]\+|\d+\.\d+[KM]/i.test(trimmed);
+  }
+
+  function replaceIfRobuxNode(node, robux) {
+    if (!node) return false;
+
+    // Roblox often has aria-labels and elements like span[title="Robux"] or specific classes.
+    // We'll target common header indicators but fall back to any element near a Robux icon.
+
+    // 1) If the node has a data-testid or known class, replace directly.
+    const text = node.textContent;
+    if (typeof text === "string" && looksLikeAbbreviated(text)) {
+      node.textContent = String(robux);
+      return true;
+    }
+    return false;
+  }
+
+  function scanAndReplace(root, robux) {
+    if (!root) return 0;
+    let replaced = 0;
+
+    // Restrict to header/nav areas to avoid touching item prices or other robux numbers.
+    const headerRoots = Array.from(
+      root.querySelectorAll('header, nav, [class*="navbar" i], [id*="nav" i], [role="navigation"]')
+    );
+    const scopedRoots = headerRoots.length ? headerRoots : [document];
+
+    const selectorList = [
+      'span[title="Robux"]',
+      '.nav-robux-balance',
+      '.icon-robux + span',
+      '.rbx-text-robux',
+      '.text-robux',
+      '[data-testid*="robux" i]',
+      '[class*="robux" i]'
+    ].join(',');
+
+    for (const container of scopedRoots) {
+      const candidates = container.querySelectorAll(selectorList);
+      candidates.forEach((el) => {
+        if (replaceIfRobuxNode(el, robux)) replaced += 1;
+      });
+
+      // Also try tight siblings of a robux icon element
+      const iconCandidates = container.querySelectorAll('[class*="icon-robux" i], [data-testid*="icon" i][data-testid*="robux" i]');
+      iconCandidates.forEach((icon) => {
+        const next = icon.nextElementSibling;
+        if (next && replaceIfRobuxNode(next, robux)) replaced += 1;
+      });
+    }
+
+    return replaced;
+  }
+
+  async function updateAll() {
+    try {
+      const robux = await requestRobux();
+      scanAndReplace(document, robux);
+    } catch (e) {
+      // Silent fail to avoid console noise for users not logged in
+    }
+  }
+
+  // Observe DOM changes so dynamically loaded headers/pages are handled.
+  const observer = new MutationObserver(() => {
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+    }
+    debounceTimer = setTimeout(() => {
+      updateAll();
+    }, 250);
+  });
+
+  function start() {
+    updateAll();
+    observer.observe(document.documentElement || document.body, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+  }
+
+  if (document.readyState === "loading") {
+    window.addEventListener("DOMContentLoaded", start, { once: true });
+  } else {
+    start();
+  }
+})();
+

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,34 @@
 {
   "manifest_version": 3,
+  "name": "Roblox Exact Robux",
+  "description": "Replaces abbreviated Robux (e.g., 1M+) with the exact balance (e.g., 1067530) across roblox.com.",
+  "version": "1.0.0",
+  "action": {
+    "default_title": "Roblox Exact Robux"
+  },
+  "permissions": [
+    "storage"
+  ],
+  "host_permissions": [
+    "https://*.roblox.com/*",
+    "https://economy.roblox.com/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "https://*.roblox.com/*"
+      ],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}
+
+{
+  "manifest_version": 3,
   "name": "Roblox Community RAP Tracker",
   "version": "1.0",
   "description": "Extract Roblox community members and rank them by RAP value from limited items",


### PR DESCRIPTION
Add a Chrome extension to display the exact Robux balance on Roblox.com by replacing abbreviated values in the header.

---
<a href="https://cursor.com/background-agent?bcId=bc-7d3ea7c8-ab36-407e-b219-2ac2c813977c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7d3ea7c8-ab36-407e-b219-2ac2c813977c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

